### PR TITLE
choire: show `yarn.lock` in GitHub diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,3 @@
 
 example/ios/**/* linguist-generated=true
 example/android/**/* linguist-generated=true
-yarn.lock linguist-generated=true


### PR DESCRIPTION
### Short description
Restore `yarn.lock` to be shown in GitHub diffs. It helps reviewers to spot unintended dependency changes.

#### List of Changes

<!--- Describe your changes in detail -->
* remove `yarn.lock` from `.gitattributes`

