### PR TITLE
feat: [SIW-742] Add `cose-js` sign and common utils

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -110,6 +110,11 @@ export default function App() {
       });
   };
 
+  const signWithCose = async () => {
+    const mockedMessage = 'A plain text to be signed';
+    await ProximityManager.signMessage(mockedMessage);
+  };
+
   const handleAndroidPermissions = () => {
     if (
       Platform.OS === 'android' &&
@@ -169,6 +174,7 @@ export default function App() {
       {(isStarted && (
         <>
           <Button title="Generate QR 🏞️" onPress={() => generateQrCode()} />
+          <Button title="Sign with COSE 📝" onPress={() => signWithCose()} />
           <Button title="Stop 🛑" onPress={() => stopProximityManager()} />
           {qrCodeUri && (
             <Image

--- a/package.json
+++ b/package.json
@@ -168,7 +168,9 @@
     ]
   },
   "dependencies": {
+    "elliptic": "^6.5.4",
     "js-crypto-hkdf": "^1.0.7",
+    "node-rsa": "^1.1.1",
     "parse-cosekey": "^1.0.2",
     "zod": "^3.22.4"
   }

--- a/src/cose/common.js
+++ b/src/cose/common.js
@@ -1,0 +1,173 @@
+/* jshint esversion: 6 */
+/* jslint node: true */
+'use strict';
+
+const Buffer = require('buffer').Buffer;
+const AlgToTags = {
+  'PS512': -39,
+  'PS384': -38,
+  'PS256': -37,
+  'RS512': -259,
+  'RS384': -258,
+  'RS256': -257,
+  'ECDH-SS-512': -28,
+  'ECDH-SS': -27,
+  'ECDH-ES-512': -26,
+  'ECDH-ES': -25,
+  'ES256': -7,
+  'ES384': -35,
+  'ES512': -36,
+  'direct': -6,
+  'A128GCM': 1,
+  'A192GCM': 2,
+  'A256GCM': 3,
+  'SHA-256_64': 4,
+  'SHA-256-64': 4,
+  'HS256/64': 4,
+  'SHA-256': 5,
+  'HS256': 5,
+  'SHA-384': 6,
+  'HS384': 6,
+  'SHA-512': 7,
+  'HS512': 7,
+  'AES-CCM-16-64-128': 10,
+  'AES-CCM-16-128/64': 10,
+  'AES-CCM-16-64-256': 11,
+  'AES-CCM-16-256/64': 11,
+  'AES-CCM-64-64-128': 12,
+  'AES-CCM-64-128/64': 12,
+  'AES-CCM-64-64-256': 13,
+  'AES-CCM-64-256/64': 13,
+  'AES-MAC-128/64': 14,
+  'AES-MAC-256/64': 15,
+  'AES-MAC-128/128': 25,
+  'AES-MAC-256/128': 26,
+  'AES-CCM-16-128-128': 30,
+  'AES-CCM-16-128/128': 30,
+  'AES-CCM-16-128-256': 31,
+  'AES-CCM-16-256/128': 31,
+  'AES-CCM-64-128-128': 32,
+  'AES-CCM-64-128/128': 32,
+  'AES-CCM-64-128-256': 33,
+  'AES-CCM-64-256/128': 33,
+};
+
+const Translators = {
+  kid: (value) => {
+    return Buffer.from(value, 'utf8');
+  },
+  alg: (value) => {
+    if (!AlgToTags[value]) {
+      throw new Error("Unknown 'alg' parameter, " + value);
+    }
+    return AlgToTags[value];
+  },
+};
+
+const HeaderParameters = {
+  partyUNonce: -22,
+  static_key_id: -3,
+  static_key: -2,
+  ephemeral_key: -1,
+  alg: 1,
+  crit: 2,
+  content_type: 3,
+  ctyp: 3, // one could question this but it makes testing easier
+  kid: 4,
+  IV: 5,
+  Partial_IV: 6,
+  counter_signature: 7,
+  x5chain: 33,
+};
+
+exports.EMPTY_BUFFER = Buffer.alloc(0);
+
+exports.TranslateHeaders = function (header) {
+  const result = new Map();
+  for (const param in header) {
+    if (!HeaderParameters[param]) {
+      throw new Error("Unknown parameter, '" + param + "'");
+    }
+    let value = header[param];
+    if (Translators[param]) {
+      value = Translators[param](header[param]);
+    }
+    if (value !== undefined && value !== null) {
+      result.set(HeaderParameters[param], value);
+    }
+  }
+  return result;
+};
+
+const KeyParameters = {
+  crv: -1,
+  k: -1,
+  x: -2,
+  y: -3,
+  d: -4,
+  kty: 1,
+};
+
+const KeyTypes = {
+  OKP: 1,
+  EC2: 2,
+  RSA: 3,
+  Symmetric: 4,
+};
+
+const KeyCrv = {
+  'P-256': 1,
+  'P-384': 2,
+  'P-521': 3,
+  'X25519': 4,
+  'X448': 5,
+  'Ed25519': 6,
+  'Ed448': 7,
+};
+
+const KeyTranslators = {
+  kty: (value) => {
+    if (!KeyTypes[value]) {
+      throw new Error("Unknown 'kty' parameter, " + value);
+    }
+    return KeyTypes[value];
+  },
+  crv: (value) => {
+    if (!KeyCrv[value]) {
+      throw new Error("Unknown 'crv' parameter, " + value);
+    }
+    return KeyCrv[value];
+  },
+};
+
+exports.TranslateKey = function (key) {
+  const result = new Map();
+  for (const param in key) {
+    if (!KeyParameters[param]) {
+      throw new Error("Unknown parameter, '" + param + "'");
+    }
+    let value = key[param];
+    if (KeyTranslators[param]) {
+      value = KeyTranslators[param](value);
+    }
+    result.set(KeyParameters[param], value);
+  }
+  return result;
+};
+
+module.exports.xor = function (a, b) {
+  const buffer = Buffer.alloc(Math.max(a.length, b.length));
+  for (let i = 1; i <= buffer.length; ++i) {
+    const av = a.length - i < 0 ? 0 : a[a.length - i];
+    const bv = b.length - i < 0 ? 0 : b[b.length - i];
+    // eslint-disable-next-line no-bitwise
+    buffer[buffer.length - i] = av ^ bv;
+  }
+  return buffer;
+};
+
+exports.HeaderParameters = HeaderParameters;
+
+exports.runningInNode = function () {
+  return Object.prototype.toString.call(global.process) === '[object process]';
+};

--- a/src/cose/index.ts
+++ b/src/cose/index.ts
@@ -1,0 +1,2 @@
+export const common = require('./common');
+export const sign = require('./sign');

--- a/src/cose/sign.js
+++ b/src/cose/sign.js
@@ -1,0 +1,276 @@
+/* jshint esversion: 6 */
+/* jslint node: true */
+'use strict';
+
+const cbor = require('cbor');
+const EC = require('elliptic').ec;
+const crypto = require('crypto');
+const NodeRSA = require('node-rsa');
+const common = require('./common');
+const EMPTY_BUFFER = common.EMPTY_BUFFER;
+const Tagged = cbor.Tagged;
+const Buffer = require('buffer').Buffer;
+
+const SignTag = (exports.SignTag = 98);
+const Sign1Tag = (exports.Sign1Tag = 18);
+
+const AlgFromTags = {};
+AlgFromTags[-7] = { sign: 'ES256', digest: 'SHA-256' };
+AlgFromTags[-35] = { sign: 'ES384', digest: 'SHA-384' };
+AlgFromTags[-36] = { sign: 'ES512', digest: 'SHA-512' };
+AlgFromTags[-37] = { sign: 'PS256', digest: 'SHA-256' };
+AlgFromTags[-38] = { sign: 'PS384', digest: 'SHA-384' };
+AlgFromTags[-39] = { sign: 'PS512', digest: 'SHA-512' };
+AlgFromTags[-257] = { sign: 'RS256', digest: 'SHA-256' };
+AlgFromTags[-258] = { sign: 'RS384', digest: 'SHA-384' };
+AlgFromTags[-259] = { sign: 'RS512', digest: 'SHA-512' };
+
+const COSEAlgToNodeAlg = {
+  ES256: { sign: 'p256', digest: 'sha256' },
+  ES384: { sign: 'p384', digest: 'sha384' },
+  ES512: { sign: 'p521', digest: 'sha512' },
+  RS256: { sign: 'RSA-SHA256' },
+  RS384: { sign: 'RSA-SHA384' },
+  RS512: { sign: 'RSA-SHA512' },
+  PS256: { alg: 'pss-sha256', saltLen: 32 },
+  PS384: { alg: 'pss-sha384', saltLen: 48 },
+  PS512: { alg: 'pss-sha512', saltLen: 64 },
+};
+
+function doSign(SigStructure, signer, alg) {
+  if (!AlgFromTags[alg]) {
+    throw new Error('Unknown algorithm, ' + alg);
+  }
+  if (!COSEAlgToNodeAlg[AlgFromTags[alg].sign]) {
+    throw new Error('Unsupported algorithm, ' + AlgFromTags[alg].sign);
+  }
+
+  let ToBeSigned = cbor.encode(SigStructure);
+
+  let sig;
+  if (AlgFromTags[alg].sign.startsWith('ES')) {
+    const hash = crypto.createHash(
+      COSEAlgToNodeAlg[AlgFromTags[alg].sign].digest
+    );
+    hash.update(ToBeSigned);
+    ToBeSigned = hash.digest();
+    const ec = new EC(COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign);
+    const key = ec.keyFromPrivate(signer.key.d);
+    const signature = key.sign(ToBeSigned);
+    const bitLength = Math.ceil(ec.curve._bitLength / 8);
+    sig = Buffer.concat([
+      signature.r.toArrayLike(Buffer, undefined, bitLength),
+      signature.s.toArrayLike(Buffer, undefined, bitLength),
+    ]);
+  } else if (AlgFromTags[alg].sign.startsWith('PS')) {
+    signer.key.dmp1 = signer.key.dp;
+    signer.key.dmq1 = signer.key.dq;
+    signer.key.coeff = signer.key.qi;
+    const key = new NodeRSA().importKey(signer.key, 'components-private');
+    key.setOptions({
+      signingScheme: {
+        scheme: COSEAlgToNodeAlg[AlgFromTags[alg].sign].alg.split('-')[0],
+        hash: COSEAlgToNodeAlg[AlgFromTags[alg].sign].alg.split('-')[1],
+        saltLength: COSEAlgToNodeAlg[AlgFromTags[alg].sign].saltLen,
+      },
+    });
+    sig = key.sign(ToBeSigned);
+  } else {
+    const sign = crypto.createSign(
+      COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign
+    );
+    sign.update(ToBeSigned);
+    sign.end();
+    sig = sign.sign(signer.key);
+  }
+  return sig;
+}
+
+exports.create = function (headers, payload, signers, options) {
+  options = options || {};
+  let u = headers.u || {};
+  let p = headers.p || {};
+
+  p = common.TranslateHeaders(p);
+  u = common.TranslateHeaders(u);
+  let bodyP = p || {};
+  bodyP = bodyP.size === 0 ? EMPTY_BUFFER : cbor.encode(bodyP);
+  if (Array.isArray(signers)) {
+    if (signers.length === 0) {
+      throw new Error('There has to be at least one signer');
+    }
+    if (signers.length > 1) {
+      throw new Error('Only one signer is supported');
+    }
+    // TODO handle multiple signers
+    const signer = signers[0];
+    const externalAAD = signer.externalAAD || EMPTY_BUFFER;
+    let signerP = signer.p || {};
+    let signerU = signer.u || {};
+
+    signerP = common.TranslateHeaders(signerP);
+    signerU = common.TranslateHeaders(signerU);
+    const alg = signerP.get(common.HeaderParameters.alg);
+    signerP = signerP.size === 0 ? EMPTY_BUFFER : cbor.encode(signerP);
+
+    const SigStructure = ['Signature', bodyP, signerP, externalAAD, payload];
+
+    const sig = doSign(SigStructure, signer, alg);
+    if (p.size === 0 && options.encodep === 'empty') {
+      p = EMPTY_BUFFER;
+    } else {
+      p = cbor.encode(p);
+    }
+    const signed = [p, u, payload, [[signerP, signerU, sig]]];
+    return cbor.encodeAsync(
+      options.excludetag ? signed : new Tagged(SignTag, signed)
+    );
+  } else {
+    const signer = signers;
+    const externalAAD = signer.externalAAD || EMPTY_BUFFER;
+    const alg =
+      p.get(common.HeaderParameters.alg) || u.get(common.HeaderParameters.alg);
+    const SigStructure = ['Signature1', bodyP, externalAAD, payload];
+    const sig = doSign(SigStructure, signer, alg);
+    if (p.size === 0 && options.encodep === 'empty') {
+      p = EMPTY_BUFFER;
+    } else {
+      p = cbor.encode(p);
+    }
+    const signed = [p, u, payload, sig];
+    return cbor.encodeAsync(
+      options.excludetag ? signed : new Tagged(Sign1Tag, signed),
+      { canonical: true }
+    );
+  }
+};
+
+function doVerify(SigStructure, verifier, alg, sig) {
+  if (!AlgFromTags[alg]) {
+    throw new Error('Unknown algorithm, ' + alg);
+  }
+  const nodeAlg = COSEAlgToNodeAlg[AlgFromTags[alg].sign];
+  if (!nodeAlg) {
+    throw new Error('Unsupported algorithm, ' + AlgFromTags[alg].sign);
+  }
+  const ToBeSigned = cbor.encode(SigStructure);
+
+  if (AlgFromTags[alg].sign.startsWith('ES')) {
+    const hash = crypto.createHash(nodeAlg.digest);
+    hash.update(ToBeSigned);
+    const msgHash = hash.digest();
+
+    const pub = { x: verifier.key.x, y: verifier.key.y };
+    const ec = new EC(nodeAlg.sign);
+    const key = ec.keyFromPublic(pub);
+    sig = { r: sig.slice(0, sig.length / 2), s: sig.slice(sig.length / 2) };
+    if (!key.verify(msgHash, sig)) {
+      throw new Error('Signature missmatch');
+    }
+  } else if (AlgFromTags[alg].sign.startsWith('PS')) {
+    const key = new NodeRSA().importKey(verifier.key, 'components-public');
+    key.setOptions({
+      signingScheme: {
+        scheme: COSEAlgToNodeAlg[AlgFromTags[alg].sign].alg.split('-')[0],
+        hash: COSEAlgToNodeAlg[AlgFromTags[alg].sign].alg.split('-')[1],
+        saltLength: COSEAlgToNodeAlg[AlgFromTags[alg].sign].saltLen,
+      },
+    });
+    if (!key.verify(ToBeSigned, sig, 'buffer', 'buffer')) {
+      throw new Error('Signature missmatch');
+    }
+  } else {
+    const verify = crypto.createVerify(nodeAlg.sign);
+    verify.update(ToBeSigned);
+    if (!verify.verify(verifier.key, sig)) {
+      throw new Error('Signature missmatch');
+    }
+  }
+}
+
+function getSigner(signers, verifier) {
+  for (let i = 0; i < signers.length; i++) {
+    const kid = signers[i][1].get(common.HeaderParameters.kid); // TODO create constant for header locations
+    if (kid.equals(Buffer.from(verifier.key.kid, 'utf8'))) {
+      return signers[i];
+    }
+  }
+}
+
+function getCommonParameter(first, second, parameter) {
+  let result;
+  if (first.get) {
+    result = first.get(parameter);
+  }
+  if (!result && second.get) {
+    result = second.get(parameter);
+  }
+  return result;
+}
+
+exports.verify = async function (payload, verifier, options) {
+  options = options || {};
+  const obj = await cbor.decodeFirst(payload);
+  return verifyInternal(verifier, options, obj);
+};
+
+exports.verifySync = function (payload, verifier, options) {
+  options = options || {};
+  const obj = cbor.decodeFirstSync(payload);
+  return verifyInternal(verifier, options, obj);
+};
+
+function verifyInternal(verifier, options, obj) {
+  options = options || {};
+  let type = options.defaultType ? options.defaultType : SignTag;
+  if (obj instanceof Tagged) {
+    if (obj.tag !== SignTag && obj.tag !== Sign1Tag) {
+      throw new Error("Unexpected cbor tag, '" + obj.tag + "'");
+    }
+    type = obj.tag;
+    obj = obj.value;
+  }
+
+  if (!Array.isArray(obj)) {
+    throw new Error('Expecting Array');
+  }
+
+  if (obj.length !== 4) {
+    throw new Error('Expecting Array of lenght 4');
+  }
+
+  let [p, u, plaintext, signers] = obj;
+
+  if (type === SignTag && !Array.isArray(signers)) {
+    throw new Error('Expecting signature Array');
+  }
+
+  p = !p.length ? EMPTY_BUFFER : cbor.decodeFirstSync(p);
+  u = !u.size ? EMPTY_BUFFER : u;
+
+  const signer = type === SignTag ? getSigner(signers, verifier) : signers;
+
+  if (!signer) {
+    throw new Error('Failed to find signer with kid' + verifier.key.kid);
+  }
+
+  if (type === SignTag) {
+    const externalAAD = verifier.externalAAD || EMPTY_BUFFER;
+    let [signerP, , sig] = signer;
+    signerP = !signerP.length ? EMPTY_BUFFER : signerP;
+    p = !p.size ? EMPTY_BUFFER : cbor.encode(p);
+    const signerPMap = cbor.decode(signerP);
+    const alg = signerPMap.get(common.HeaderParameters.alg);
+    const SigStructure = ['Signature', p, signerP, externalAAD, plaintext];
+    doVerify(SigStructure, verifier, alg, sig);
+    return plaintext;
+  } else {
+    const externalAAD = verifier.externalAAD || EMPTY_BUFFER;
+
+    const alg = getCommonParameter(p, u, common.HeaderParameters.alg);
+    p = !p.size ? EMPTY_BUFFER : cbor.encode(p);
+    const SigStructure = ['Signature1', p, externalAAD, plaintext];
+    doVerify(SigStructure, verifier, alg, signer);
+    return plaintext;
+  }
+}

--- a/src/proximity-manager/index.ts
+++ b/src/proximity-manager/index.ts
@@ -12,6 +12,7 @@ import { CborDataItem, decode, encode } from '../cbor';
 import { uuidToBuffer } from '../utils';
 import { removePadding } from '@pagopa/io-react-native-jwt';
 import { documentsRequestParser, type DocumentRequest } from './parser';
+import { sign } from '../cose';
 
 /**
   * This package is a boilerplate for native modules. No native code is included here.
@@ -325,6 +326,30 @@ const ProximityManager = () => {
     }
   };
 
+  // TODO: this function is used to test COSE sign
+  // on a mocked plaintext. It should be removed
+  // or moved where appropriate.
+  const signMessage = async (message: string) => {
+    try {
+      const headers = {
+        p: { alg: 'ES256' },
+        u: { kid: '11' },
+      };
+      const signer = {
+        key: {
+          d: Buffer.from(
+            '6c1382765aec5358f117733d281c1c7bdc39884d04a45a1e6c67c858bc206c19',
+            'hex'
+          ),
+        },
+      };
+      const buf = await sign.create(headers, message, signer);
+      console.log('Signed message: ' + buf.toString('hex'));
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   /**
    * This function is called when the mDL-reader is ready to receive the credential.
    * @param credential
@@ -403,6 +428,7 @@ const ProximityManager = () => {
     start,
     startScan,
     generateQrCode,
+    signMessage,
     setListeners,
     setOnDocumentRequestHandler,
     stop,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2673,11 +2673,13 @@ __metadata:
     cbor-x: ^1.5.6
     commitlint: ^17.0.2
     del-cli: ^5.0.0
+    elliptic: ^6.5.4
     eslint: ^8.4.1
     eslint-config-prettier: ^8.5.0
     eslint-plugin-prettier: ^4.0.0
     jest: ^28.1.1
     js-crypto-hkdf: ^1.0.7
+    node-rsa: ^1.1.1
     parse-cosekey: ^1.0.2
     pod-install: ^0.1.0
     prettier: ^2.0.5
@@ -3942,6 +3944,15 @@ __metadata:
     minimalistic-assert: ^1.0.0
     safer-buffer: ^2.1.0
   checksum: 3786a101ac6f304bd4e9a7df79549a7561950a13d4bcaec0c7790d44c80d147c1a94ba3d4e663673406064642a40b23fcd6c82a9952468e386c1a1376d747f9a
+  languageName: node
+  linkType: hard
+
+"asn1@npm:^0.2.4":
+  version: 0.2.6
+  resolution: "asn1@npm:0.2.6"
+  dependencies:
+    safer-buffer: ~2.1.0
+  checksum: 39f2ae343b03c15ad4f238ba561e626602a3de8d94ae536c46a4a93e69578826305366dc09fbb9b56aec39b4982a463682f259c38e59f6fa380cd72cd61e493d
   languageName: node
   linkType: hard
 
@@ -10537,6 +10548,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-rsa@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "node-rsa@npm:1.1.1"
+  dependencies:
+    asn1: ^0.2.4
+  checksum: c03a6c8f69557326d2110086ce9610b4b17ef0fd594f76202225b7eb93fc0b342fb31714f6b3cf8d38320cf63c4790a3034e5d47a12f2c27d1900599ec9bd545
+  languageName: node
+  linkType: hard
+
 "node-stream-zip@npm:^1.9.1":
   version: 1.15.0
   resolution: "node-stream-zip@npm:1.15.0"
@@ -12343,7 +12363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.1.0":
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.1.0, safer-buffer@npm:~2.1.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0


### PR DESCRIPTION
### Short description

This PR adds `cose-js` utils to get encryption on cbor. This PR adds only base cose-js utils methods. In another PR we refactor the `doSign` method to perform an encryption using `io-react-native-crypto` to access SE/TEE.

Note: The `cose-js` files are base on this repository https://github.com/erdtman/cose-js

#### List of Changes

- Add `cose` directory with sign and common utils
- Add `node-rsa` as dependency
- Add `elliptic` as dependency
- Update example app to test COSE sign on a mocked plain text
- Update temp function in `ProximityManager` to perform a COSE sign

#### How Has This Been Tested?

#### Screenshots (if appropriate):
