### PR TITLE
chore: Remove cbor-x as peer dependencies

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -80,7 +80,7 @@ PODS:
     - JOSESwift (~> 2.3)
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - pagopa-io-react-native-proximity (0.1.0):
+  - pagopa-io-react-native-proximity (0.1.1):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - RCT-Folly (2021.07.22.00):
@@ -709,7 +709,7 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   pagopa-io-react-native-jwt: 637df21a8a7839c70e52c4a7614a04cca7335fb3
-  pagopa-io-react-native-proximity: 5a91c68b65e84288af45d38ebff1d0a9a353c5f2
+  pagopa-io-react-native-proximity: 1fdf967a5afb3c75ef518c56309c297d90168139
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 28469809442eb4eb5528462705f7d852948c8a74
   RCTTypeSafety: e9c6c409fca2cc584e5b086862d562540cb38d29

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-proximity",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A RN library to get proximity flow based on ISO-18013",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-proximity",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A RN library to get proximity flow based on ISO-18013",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -58,7 +58,6 @@
     "@types/jest": "^28.1.2",
     "@types/react": "~17.0.21",
     "@types/react-native": "0.70.0",
-    "cbor-x": "^1.5.6",
     "commitlint": "^17.0.2",
     "del-cli": "^5.0.0",
     "eslint": "^8.4.1",
@@ -81,7 +80,6 @@
   },
   "peerDependencies": {
     "@pagopa/io-react-native-jwt": "*",
-    "cbor-x": "*",
     "react": "*",
     "react-native": "*",
     "react-native-ble-manager": "*",
@@ -168,6 +166,7 @@
     ]
   },
   "dependencies": {
+    "cbor-x": "^1.5.6",
     "js-crypto-hkdf": "^1.0.7",
     "parse-cosekey": "^1.0.2",
     "zod": "^3.22.4"

--- a/src/cbor/index.ts
+++ b/src/cbor/index.ts
@@ -1,4 +1,4 @@
-import { Encoder, addExtension } from 'cbor-x';
+import { Encoder, addExtension } from 'cbor-x/encode';
 
 export class CborDataItem {
   cborDataItem: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,7 +2692,6 @@ __metadata:
     zod: ^3.22.4
   peerDependencies:
     "@pagopa/io-react-native-jwt": "*"
-    cbor-x: "*"
     react: "*"
     react-native: "*"
     react-native-ble-manager: "*"


### PR DESCRIPTION
It inserts cbor-x as a package dependency and no longer as a peer dependency since it does not contain native code