### PR TITLE
fix: [WLEO-338] Send response not working properly

### DIFF
--- a/android/src/main/java/com/pagopa/ioreactnativeproximity/IoReactNativeProximityModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativeproximity/IoReactNativeProximityModule.kt
@@ -179,7 +179,7 @@ class IoReactNativeProximityModule(reactContext: ReactApplicationContext) :
             }
           })
       } ?: run {
-        ModuleException.QR_ENGAGEMENT_NOT_DEFINED_ERROR.reject(promise)
+        ModuleException.DRH_NOT_DEFINED.reject(promise)
       }
     } catch (e: Exception) {
       ModuleException.GENERIC_GENERATE_RESPONSE_ERROR.reject(

--- a/android/src/main/java/com/pagopa/ioreactnativeproximity/IoReactNativeProximityModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativeproximity/IoReactNativeProximityModule.kt
@@ -155,38 +155,32 @@ class IoReactNativeProximityModule(reactContext: ReactApplicationContext) :
   ) {
     try {
       deviceRetrievalHelper?.let { devHelper ->
-        qrEngagement?.let { qrEng ->
-          // Get the DocRequested list and if it's empty then reject the promise and return
-          val docRequestedList = getDocRequestedArrayList(documents)
-          if (docRequestedList.isEmpty()) {
-            ModuleException.WRONG_DOCUMENTS_FORMAT.reject(promise)
-            return
-          }
-
-          val sessionTranscript = devHelper.sessionTranscript()
-          val responseGenerator = ResponseGenerator(sessionTranscript)
-          responseGenerator.createResponse(docRequestedList.toTypedArray(),
-            fieldRequestedAndAccepted,
-            object : ResponseGenerator.Response {
-              override fun onResponseGenerated(response: ByteArray) {
-                qrEng.sendResponse(response)
-                promise.resolve(Base64.encodeToString(response, Base64.NO_WRAP))
-              }
-
-              override fun onError(message: String) {
-                ModuleException.RESPONSE_GENERATION_ON_ERROR.reject(
-                  promise,
-                  Pair(ERROR_KEY, message)
-                )
-              }
-            })
-        } ?: run {
-          ModuleException.QR_ENGAGEMENT_NOT_DEFINED_ERROR.reject(promise)
+        // Get the DocRequested list and if it's empty then reject the promise and return
+        val docRequestedList = getDocRequestedArrayList(documents)
+        if (docRequestedList.isEmpty()) {
+          ModuleException.WRONG_DOCUMENTS_FORMAT.reject(promise)
+          return
         }
-      } ?: run {
-        ModuleException.DRH_NOT_DEFINED.reject(promise)
-      }
 
+        val sessionTranscript = devHelper.sessionTranscript()
+        val responseGenerator = ResponseGenerator(sessionTranscript)
+        responseGenerator.createResponse(docRequestedList.toTypedArray(),
+          fieldRequestedAndAccepted,
+          object : ResponseGenerator.Response {
+            override fun onResponseGenerated(response: ByteArray) {
+              promise.resolve(Base64.encodeToString(response, Base64.NO_WRAP))
+            }
+
+            override fun onError(message: String) {
+              ModuleException.RESPONSE_GENERATION_ON_ERROR.reject(
+                promise,
+                Pair(ERROR_KEY, message)
+              )
+            }
+          })
+      } ?: run {
+        ModuleException.QR_ENGAGEMENT_NOT_DEFINED_ERROR.reject(promise)
+      }
     } catch (e: Exception) {
       ModuleException.GENERIC_GENERATE_RESPONSE_ERROR.reject(
         promise,
@@ -199,14 +193,13 @@ class IoReactNativeProximityModule(reactContext: ReactApplicationContext) :
   fun sendResponse(response: String, promise: Promise) {
     try {
       qrEngagement?.let { qrEng ->
-        {
-          val responseBytes = Base64.decode(response, Base64.NO_WRAP)
-          qrEng.sendResponse(responseBytes)
-          promise.resolve(true)
-        }
-      } ?: run {
-        ModuleException.QR_ENGAGEMENT_NOT_DEFINED_ERROR.reject(promise)
+        val responseBytes = Base64.decode(response, Base64.NO_WRAP)
+        qrEng.sendResponse(responseBytes)
+        promise.resolve(true)
       }
+        ?: run {
+          ModuleException.QR_ENGAGEMENT_NOT_DEFINED_ERROR.reject(promise)
+        }
     } catch (e: Exception) {
       ModuleException.SEND_RESPONSE_ERROR.reject(
         promise,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,9 +57,7 @@ interface IoReactNativeProximity {
     fieldRequestedAndAccepted: string
   ): Promise<string>;
 
-  sendResponse(
-    response: ReturnType<typeof IoReactNativeProximity.generateResponse>
-  ): Promise<boolean>;
+  sendResponse(response: string): Promise<boolean>;
 
   addListener<E extends QrEngagementEvents>(
     event: E,


### PR DESCRIPTION
### Short description
This PR fixes an issue causes the send response not to work properly. The presentation was still successful because of the `sendResponse` being wrongly called inside the `generateResponse` function
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Remove the `sendResponse` from `generateResponse`; 
- Fix the `let` null check in `sendResponse`. 
<!--- Describe your changes in detail -->

#### How Has This Been Tested?
Test a proximity presentation flow. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->