### PR TITLE
chore: [WLEO-341] Update native dependency for android to version 1.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "it.pagopa.io.wallet.proximity:proximity:1.1.1"
+  implementation "it.pagopa.io.wallet.proximity:proximity:1.2.0"
   implementation "com.upokecenter:cbor:4.5.6"
 }
 

--- a/android/src/main/java/com/pagopa/ioreactnativeproximity/IoReactNativeProximityModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativeproximity/IoReactNativeProximityModule.kt
@@ -128,7 +128,6 @@ class IoReactNativeProximityModule(reactContext: ReactApplicationContext) :
       (0 until documents.size())
         .mapNotNull { i ->
           val doc = documents.getMap(i)
-          Log.i("TEST", doc.toString())
           val alias = doc.getString("alias")
           val issuerSignedContent = doc.getString("issuerSignedContent")
           val docType = doc.getString("docType")
@@ -157,7 +156,6 @@ class IoReactNativeProximityModule(reactContext: ReactApplicationContext) :
     promise: Promise
   ) {
     try {
-      Log.i("TEST", fieldRequestedAndAccepted.toString())
       deviceRetrievalHelper?.let { devHelper ->
         // Get the DocRequested list and if it's empty then reject the promise and return
         val docRequestedList = getDocRequestedArrayList(documents)

--- a/android/src/main/java/com/pagopa/ioreactnativeproximity/IoReactNativeProximityModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativeproximity/IoReactNativeProximityModule.kt
@@ -13,7 +13,6 @@ import it.pagopa.io.wallet.proximity.request.DocRequested
 import it.pagopa.io.wallet.proximity.response.ResponseGenerator
 import it.pagopa.io.wallet.proximity.wrapper.DeviceRetrievalHelperWrapper
 import android.util.Base64
-import android.util.Log
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeMap

--- a/android/src/main/java/com/pagopa/ioreactnativeproximity/IoReactNativeProximityModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativeproximity/IoReactNativeProximityModule.kt
@@ -13,7 +13,9 @@ import it.pagopa.io.wallet.proximity.request.DocRequested
 import it.pagopa.io.wallet.proximity.response.ResponseGenerator
 import it.pagopa.io.wallet.proximity.wrapper.DeviceRetrievalHelperWrapper
 import android.util.Base64
+import android.util.Log
 import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeMap
 
 class IoReactNativeProximityModule(reactContext: ReactApplicationContext) :
@@ -126,6 +128,7 @@ class IoReactNativeProximityModule(reactContext: ReactApplicationContext) :
       (0 until documents.size())
         .mapNotNull { i ->
           val doc = documents.getMap(i)
+          Log.i("TEST", doc.toString())
           val alias = doc.getString("alias")
           val issuerSignedContent = doc.getString("issuerSignedContent")
           val docType = doc.getString("docType")
@@ -150,10 +153,11 @@ class IoReactNativeProximityModule(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun generateResponse(
     documents: ReadableArray,
-    fieldRequestedAndAccepted: String,
+    fieldRequestedAndAccepted: ReadableMap,
     promise: Promise
   ) {
     try {
+      Log.i("TEST", fieldRequestedAndAccepted.toString())
       deviceRetrievalHelper?.let { devHelper ->
         // Get the DocRequested list and if it's empty then reject the promise and return
         val docRequestedList = getDocRequestedArrayList(documents)
@@ -165,7 +169,7 @@ class IoReactNativeProximityModule(reactContext: ReactApplicationContext) :
         val sessionTranscript = devHelper.sessionTranscript()
         val responseGenerator = ResponseGenerator(sessionTranscript)
         responseGenerator.createResponse(docRequestedList.toTypedArray(),
-          fieldRequestedAndAccepted,
+          fieldRequestedAndAccepted.toString(),
           object : ResponseGenerator.Response {
             override fun onResponseGenerated(response: ByteArray) {
               promise.resolve(Base64.encodeToString(response, Base64.NO_WRAP))

--- a/example/src/screens/QrCodeScreen.tsx
+++ b/example/src/screens/QrCodeScreen.tsx
@@ -59,7 +59,6 @@ export const QrCodeScreen: React.FC = () => {
 
         // Parse and verify the received request with the exposed function
         const message = data.message;
-        console.log('test', message);
         const parsedJson = JSON.parse(message);
         console.log('Parsed JSON:', parsedJson);
         const parsedResponse = parseVerifierRequest(parsedJson);

--- a/example/src/screens/QrCodeScreen.tsx
+++ b/example/src/screens/QrCodeScreen.tsx
@@ -59,7 +59,9 @@ export const QrCodeScreen: React.FC = () => {
 
         // Parse and verify the received request with the exposed function
         const message = data.message;
+        console.log('test', message);
         const parsedJson = JSON.parse(message);
+        console.log('Parsed JSON:', parsedJson);
         const parsedResponse = parseVerifierRequest(parsedJson);
         console.log('Parsed response:', JSON.stringify(parsedResponse));
 

--- a/example/src/utils.ts
+++ b/example/src/utils.ts
@@ -12,7 +12,7 @@ import {
   RESULTS,
 } from 'react-native-permissions';
 import { WELL_KNOWN_CREDENTIALS } from './mocks';
-import type { VerifierRequest } from '../../src/schema';
+import type { AcceptedFields, VerifierRequest } from '../../src/schema';
 
 /**
  * This function generates the accepted fields for the VerifierRequest and sets each requested field to true.
@@ -20,19 +20,49 @@ import type { VerifierRequest } from '../../src/schema';
  * @returns A new object with the same structure as the request, but with all values set to true
  */
 export const generateAcceptedFields = (
-  request: VerifierRequest['request']
-): VerifierRequest['request'] => {
-  const result: VerifierRequest['request'] = {};
-  for (const key1 in request) {
-    result[key1] = {};
-    for (const key2 in request[key1]) {
-      result[key1][key2] = {};
-      for (const key3 in request[key1][key2]) {
-        result[key1][key2][key3] = true;
-      }
-    }
-  }
-  return result;
+  _: VerifierRequest['request']
+): AcceptedFields => {
+  //TODO implement a more generic solution to generate the accepted fields
+  const acceptedFields: AcceptedFields = {
+    'org.iso.18013.5.1.mDL': {
+      'org.iso.18013.5.1': {
+        height: true,
+        weight: true,
+        portrait: true,
+        birth_date: true,
+        eye_colour: true,
+        given_name: true,
+        issue_date: true,
+        age_over_18: true,
+        age_over_21: true,
+        birth_place: true,
+        expiry_date: true,
+        family_name: true,
+        hair_colour: true,
+        nationality: true,
+        age_in_years: true,
+        resident_city: true,
+        age_birth_year: true,
+        resident_state: true,
+        document_number: true,
+        issuing_country: true,
+        resident_address: true,
+        resident_country: true,
+        issuing_authority: true,
+        driving_privileges: true,
+        issuing_jurisdiction: true,
+        resident_postal_code: true,
+        signature_usual_mark: true,
+        administrative_number: true,
+        portrait_capture_date: true,
+        un_distinguishing_sign: true,
+        given_name_national_character: true,
+        family_name_national_character: true,
+      },
+    },
+  };
+
+  return acceptedFields;
 };
 
 /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
-import type { VerifierRequest } from './schema';
+import type { AcceptedFields } from './schema';
 
 const LINKING_ERROR =
   `The package '@pagopa/io-react-native-proximity' doesn't seem to be linked. Make sure: \n\n` +
@@ -116,7 +116,7 @@ export function sendErrorResponseNoData(): Promise<boolean> {
  */
 export function generateResponse(
   documents: Array<Document>,
-  acceptedFields: VerifierRequest['request']
+  acceptedFields: AcceptedFields
 ): Promise<string> {
   return IoReactNativeProximity.generateResponse(documents, acceptedFields);
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,11 +1,16 @@
 import { z } from 'zod';
 
+// Inner data: a record of booleans with the attributes and the intent to retain flag
+const booleanFieldGroup = z.record(z.boolean());
+
+const credentialEntrySchema = z
+  .object({
+    isAuthenticated: z.boolean(),
+  })
+  .catchall(booleanFieldGroup);
+
 const VerifierRequest = z.object({
-  isAuthenticated: z.boolean(),
-  request: z.record(
-    z.string(),
-    z.record(z.string(), z.record(z.string(), z.boolean()))
-  ),
+  request: z.record(credentialEntrySchema),
 });
 
 /**
@@ -36,4 +41,10 @@ export type VerifierRequest = z.infer<typeof VerifierRequest>;
  */
 export const parseVerifierRequest = (input: unknown): VerifierRequest => {
   return VerifierRequest.parse(input);
+};
+
+export type AcceptedFields = {
+  [key: string]: {
+    [key: string]: { [key: string]: boolean };
+  };
 };


### PR DESCRIPTION
> [!WARNING] 
> This breaks the iOS implementation which will be aligned in another PR. Also the accepted fields object is mocked for a full MDL only.

### Short description
This PR aligns the bridge implementation to the native dependency version `1.2.0`. It includes a change on the device request which now includes the `isAuthenticated` flag for each document requested instead of the whole request. 
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Update the native proximity dependency to version `1.2.0`; 
- Align the Zod type used to parse the device response according to the new structure including `isAuthenticated` for each document instead of the whole request; 
- Temporary mock the function which generates the object with the accepted fields. 
<!--- Describe your changes in detail -->

#### How Has This Been Tested?
Launch the example app and test a proximity presentation with the reference implementation verifier app asking for a full MDL.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->