### PR TITLE
chore: [WLEO-423] Remove unused CBOR dependency from Android 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,6 +85,5 @@ dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "it.pagopa.io.wallet.proximity:proximity:1.4.0"
-  implementation "com.upokecenter:cbor:4.5.6"
 }
 


### PR DESCRIPTION
### Short description
This PR removes the unused `com.upokecenter:cbor:4.5.6` dependency which was included for testing purposes.
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
#### List of Changes
- Remove `com.upokecenter:cbor:4.5.6` from the project `build.gradle`.
<!--- Describe your changes in detail -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Test a presentation flow on Android.
#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->